### PR TITLE
Reduce memory allocations by native libraries.

### DIFF
--- a/src/main/java/com/voxelwind/server/jni/hash/NativeHash.java
+++ b/src/main/java/com/voxelwind/server/jni/hash/NativeHash.java
@@ -6,13 +6,12 @@ import io.netty.buffer.ByteBuf;
 public class NativeHash implements VoxelwindHash
 {
 
-    private final NativeHashImpl impl;
+    private static final NativeHashImpl impl = new NativeHashImpl();
     private final long ctx;
     private boolean completed = false;
 
     public NativeHash()
     {
-        impl = new NativeHashImpl();
         ctx = impl.init();
     }
 
@@ -31,7 +30,8 @@ public class NativeHash implements VoxelwindHash
     }
 
     @Override
-    public byte[] digest() {
+    public byte[] digest()
+    {
         checkState();
         byte[] digest = impl.digest(ctx);
         completed = true;

--- a/src/main/java/net/md_5/bungee/jni/cipher/NativeCipher.java
+++ b/src/main/java/net/md_5/bungee/jni/cipher/NativeCipher.java
@@ -3,15 +3,14 @@ package net.md_5.bungee.jni.cipher;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import lombok.Getter;
+
 import javax.crypto.SecretKey;
 import java.security.GeneralSecurityException;
 
 public class NativeCipher implements BungeeCipher
 {
 
-    @Getter
-    private final NativeCipherImpl nativeCipher = new NativeCipherImpl();
+    private static final NativeCipherImpl impl = new NativeCipherImpl();
     /*============================================================================*/
     private long ctx;
 
@@ -23,7 +22,7 @@ public class NativeCipher implements BungeeCipher
         Preconditions.checkArgument( key.getEncoded().length == 32, "Not a 256-bit AES key");
         Preconditions.checkArgument( iv.length == 16, "IV must be 16 bytes long");
 
-        this.ctx = nativeCipher.init( forEncryption, key.getEncoded(), iv );
+        this.ctx = impl.init( forEncryption, key.getEncoded(), iv );
     }
 
     @Override
@@ -31,7 +30,7 @@ public class NativeCipher implements BungeeCipher
     {
         if ( ctx != 0 )
         {
-            nativeCipher.free( ctx );
+            impl.free( ctx );
             ctx = 0;
         }
     }
@@ -56,7 +55,7 @@ public class NativeCipher implements BungeeCipher
         out.ensureWritable( length );
 
         // Cipher the bytes
-        nativeCipher.cipher( ctx, in.memoryAddress() + in.readerIndex(), out.memoryAddress() + out.writerIndex(), length );
+        impl.cipher( ctx, in.memoryAddress() + in.readerIndex(), out.memoryAddress() + out.writerIndex(), length );
 
         // Go to the end of the buffer, all bytes would of been read
         in.readerIndex( in.writerIndex() );


### PR DESCRIPTION
NativeCipher and NativeHash's backing native code don't store any state (they always use contexts), so it is safe to share instances. (In theory, NativeZlib can use a ThreadLocal, but Voxelwind already does this.)

This is more apparent with NativeHash as an instance is created every time a packet is sent.